### PR TITLE
fix(ci): Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
This pull request introduces a minor update to the CI workflow configuration. The change sets explicit permissions for the workflow to improve security.

* Security improvement:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R2): Added a `permissions` block to restrict workflow access to read-only for repository contents.

Closes [https://github.com/saviobatista/vitae/security/code-scanning/1](https://github.com/saviobatista/vitae/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents, set `permissions: contents: read` at the top level of the workflow file (just after the `name:` and before `on:`). This ensures all jobs in the workflow inherit these minimal permissions unless overridden. No changes to the jobs or steps are required, and no additional imports or definitions are needed.

---


