### PR TITLE
feat(7): normalize and clean segmented resume blocks

### DIFF
--- a/lib/parser/normalize.ts
+++ b/lib/parser/normalize.ts
@@ -1,0 +1,23 @@
+export function normalizeWhitespace(input: string): string {
+  const unicodeNormalized =
+    typeof input.normalize === "function" ? input.normalize("NFKC") : input;
+
+  const lineBreaksNormalized = unicodeNormalized.replace(/\r\n?/g, "\n");
+
+  const spacesStandardized = lineBreaksNormalized.replace(/\u00A0|\t/g, " ");
+
+  const lineEndsTrimmed = spacesStandardized
+    .split("\n")
+    .map((line) => line.replace(/[ ]+$/g, ""))
+    .join("\n");
+
+  const spacesCollapsed = lineEndsTrimmed.replace(/[ ]{2,}/g, " ");
+
+  const dashesNormalized = spacesCollapsed.replace(/[–—]/g, "–");
+
+  const paragraphsNormalized = dashesNormalized.replace(/\n{3,}/g, "\n\n");
+
+  const result = paragraphsNormalized.trim();
+
+  return result;
+}

--- a/lib/parser/normalize.ts
+++ b/lib/parser/normalize.ts
@@ -1,3 +1,8 @@
+import type { DatesLocale, NormalizeOptions } from "@/types";
+
+/**
+ * 1) Base cleanup: unicode, line breaks, spaces, dashes, paragraphs.
+ */
 export function normalizeWhitespace(input: string): string {
   const unicodeNormalized =
     typeof input.normalize === "function" ? input.normalize("NFKC") : input;
@@ -20,4 +25,157 @@ export function normalizeWhitespace(input: string): string {
   const result = paragraphsNormalized.trim();
 
   return result;
+}
+
+/**
+ * Heuristics for joining:
+ */
+const isBullet = (line: string): boolean =>
+  /^[\s]*([-*•–]\s+|\d+\.\s+)/.test(line);
+
+const isCapsHeader = (line: string): boolean => {
+  const clean = line.trim();
+  if (clean === "") return false;
+  const words = clean.split(/\s+/);
+  if (words.length < 2) return false;
+  const upperCount = words.filter(
+    (w) => w.length > 1 && w === w.toUpperCase()
+  ).length;
+  return upperCount >= Math.max(2, Math.floor(words.length * 0.6));
+};
+
+const canJoinWithNext = (next: string): boolean =>
+  next !== "" && !isBullet(next) && !isCapsHeader(next);
+
+const joinPair = (curr: string, next: string): string =>
+  /[A-Za-zÀ-ÿ]-$/.test(curr) ? curr.slice(0, -1) + next : `${curr} ${next}`;
+
+/**
+ * 2) Join lines that belong to the same sentence/section.
+ */
+export function smartJoinLines(input: string): string {
+  const lines = input.split("\n").map((l) => l.trim());
+
+  const process = (rest: string[], acc: string[]): string[] => {
+    if (rest.length === 0) return acc;
+
+    const curr = rest[0];
+    if (curr === "") return process(rest.slice(1), acc.concat(""));
+
+    const next = rest[1] ?? "";
+    const shouldJoin = canJoinWithNext(next);
+
+    if (shouldJoin) {
+      const merged = joinPair(curr, next);
+      return process([merged, ...rest.slice(2)], acc);
+    }
+
+    return process(rest.slice(1), acc.concat(curr));
+  };
+
+  return process(lines, []).join("\n");
+}
+
+/**
+ * 3) Dates: normalize ranges using locale (i18n).
+ */
+const escapeForRegex = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const normalizeConnectors = (s: string): string =>
+  s.replace(/\s*(?:to|–|—|-)\s*/gi, " – ");
+
+const buildRangeRegex = (locale: DatesLocale): RegExp => {
+  const monthKeys = Object.keys(locale.months).map((k) => escapeForRegex(k));
+  const openWords = locale.openRange.map((w) => escapeForRegex(w));
+  const monthPattern = monthKeys.join("|");
+  const yearPattern = "\\d{4}";
+  return new RegExp(
+    `(?<m1>${monthPattern})?\\s*(?<y1>${yearPattern})\\s*–\\s*(?:(?<m2>${monthPattern})?\\s*(?<y2>${yearPattern})|(?<open>${openWords.join("|")}))`,
+    "gi"
+  );
+};
+
+const replaceWithISO = (s: string, re: RegExp, locale: DatesLocale): string =>
+  s.replace(
+    re,
+    (_m, _m1, _y1, _m2, _y2, _open, _i, _str, g: Record<string, string>) => {
+      const y1 = g.y1;
+      const m1 = g.m1 ? locale.months[String(g.m1).toLowerCase()] : null;
+      const y2 = g.y2;
+      const m2 = g.m2 ? locale.months[String(g.m2).toLowerCase()] : null;
+      const open = g.open;
+
+      const left = m1 ? `${y1}-${m1}` : y1;
+      const right = open ? "Present" : m2 ? `${y2}-${m2}` : y2;
+
+      return `${left} - ${right}`;
+    }
+  );
+
+const normalizeYearToYear = (s: string): string =>
+  s.replace(
+    /(?<!\d)(\d{4})\s*[–-]\s*(\d{4})(?!\d)/g,
+    (_m, a: string, b: string) => `${a} - ${b}`
+  );
+
+export function normalizeDateRanges(
+  input: string,
+  locale: DatesLocale
+): string {
+  const connectorsNormalized = normalizeConnectors(input);
+  const rangeRegex = buildRangeRegex(locale);
+  const monthYearNormalized = replaceWithISO(
+    connectorsNormalized,
+    rangeRegex,
+    locale
+  );
+  const yearYearNormalized = normalizeYearToYear(monthYearNormalized);
+  const result = yearYearNormalized;
+  return result;
+}
+
+/** Merge extra open-range words from options into the locale (lowercased + unique). */
+const mergeOpenRange = (
+  locale: DatesLocale,
+  opts?: NormalizeOptions
+): DatesLocale => {
+  if (!opts?.dateRangePattern || opts.dateRangePattern.length === 0)
+    return locale;
+  const extras = opts.dateRangePattern.map((w) => w.toLowerCase());
+  const merged = Array.from(new Set([...(locale.openRange ?? []), ...extras]));
+  return { months: locale.months, openRange: merged };
+};
+
+const DEFAULTS: Required<
+  Pick<NormalizeOptions, "newlineWhiteSpace" | "joinLineSection">
+> = {
+  newlineWhiteSpace: true,
+  joinLineSection: true,
+};
+
+export function normalizeBlock(input: string, locale: DatesLocale): string;
+export function normalizeBlock(
+  input: string,
+  locale: DatesLocale,
+  options: NormalizeOptions
+): string;
+
+export function normalizeBlock(
+  input: string,
+  locale: DatesLocale,
+  options?: NormalizeOptions
+): string {
+  const opts = { ...DEFAULTS, ...(options ?? {}) };
+  const effectiveLocale = mergeOpenRange(locale, options);
+
+  const afterWhitespace = opts.newlineWhiteSpace
+    ? normalizeWhitespace(input)
+    : input;
+  const afterJoin = opts.joinLineSection
+    ? smartJoinLines(afterWhitespace)
+    : afterWhitespace;
+  const afterDates = normalizeDateRanges(afterJoin, effectiveLocale);
+
+  return afterDates.trim();
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -141,3 +141,13 @@ export class SegmentationError extends Error {
     this.name = "SegmentationError";
   }
 }
+
+/**
+ * Normalize and segmented resume blocks
+ */
+
+export type NormalizeOptions = {
+  newlineWhiteSpace?: boolean;
+  joinLineSection?: boolean;
+  dateRangePattern?: string[];
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -151,3 +151,12 @@ export type NormalizeOptions = {
   joinLineSection?: boolean;
   dateRangePattern?: string[];
 };
+
+/**
+ * DataLocale base
+ */
+
+export type DatesLocale = {
+  months: Record<string, string>;
+  openRange: string[];
+};

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -30,5 +30,47 @@
     "sep": {
       "middot": "\\u2022"
     }
+  },
+  "parser": {
+    "dates": {
+      "months": {
+        "jan": "01",
+        "january": "01",
+        "jan.": "01",
+        "feb": "02",
+        "february": "02",
+        "feb.": "02",
+        "mar": "03",
+        "march": "03",
+        "mar.": "03",
+        "apr": "04",
+        "april": "04",
+        "apr.": "04",
+        "may": "05",
+        "jun": "06",
+        "june": "06",
+        "jun.": "06",
+        "jul": "07",
+        "july": "07",
+        "jul.": "07",
+        "aug": "08",
+        "august": "08",
+        "aug.": "08",
+        "sep": "09",
+        "sept": "09",
+        "september": "09",
+        "sep.": "09",
+        "oct": "10",
+        "october": "10",
+        "oct.": "10",
+        "nov": "11",
+        "november": "11",
+        "nov.": "11",
+        "dec": "12",
+        "december": "12",
+        "dec.": "12"
+      },
+      "openRange": ["present", "now"]
+    }
   }
 }

--- a/tests/parser/normalize.test.ts
+++ b/tests/parser/normalize.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import en from "@/i18n/messages/en.json";
+import extractText from "@/parser/extractText";
+import { normalizeBlock } from "@/parser/normalize";
+
+const fixturesDir = path.resolve(__dirname, "..", "fixtures");
+const singlePdfPath = path.join(fixturesDir, "sample.pdf");
+const hasSingleFixture = existsSync(singlePdfPath);
+const multiPdfPath = path.join(fixturesDir, "sample-multi-page.pdf");
+const hasMultiFixture = existsSync(multiPdfPath);
+
+const L = en.parser.dates;
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  const ab = new ArrayBuffer(buf.byteLength);
+  new Uint8Array(ab).set(buf);
+  return ab;
+}
+
+const normNL = (s: string) => s.replace(/\r\n?/g, "\n");
+
+const hasAlpha = (s: string) => /[A-Za-zÀ-ÿ]/.test(s);
+const ISO_RANGE_RE = /\b\d{4}(?:-\d{2})?\s-\s(?:\d{4}(?:-\d{2})?|Present)\b/;
+
+describe("Integration: extractText + normalizeBlock", () => {
+  it.runIf(hasSingleFixture)(
+    "normalizes sample.pdf (single page)",
+    async () => {
+      const buffer = await readFile(singlePdfPath);
+      const text = await extractText(toArrayBuffer(buffer));
+
+      expect(typeof text).toBe("string");
+      expect(text.length).toBeGreaterThan(10);
+
+      const normalized = normalizeBlock(text, L);
+
+      expect(typeof normalized).toBe("string");
+      expect(normalized.length).toBeGreaterThan(10);
+      expect(hasAlpha(normalized)).toBe(true);
+
+      expect(normalized).not.toMatch(/ {2,}/);
+      expect(normalized).not.toMatch(/\n{3,}/);
+      for (const line of normNL(normalized).split("\n")) {
+        expect(line.endsWith(" ")).toBe(false);
+      }
+
+      if (
+        /\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|Present|Now|20\d{2})\b/i.test(
+          normalized
+        )
+      ) {
+        expect(ISO_RANGE_RE.test(normalized)).toBe(true);
+      }
+    },
+    30_000
+  );
+
+  it.runIf(hasMultiFixture)(
+    "normalizes sample-multi-page.pdf",
+    async () => {
+      const buffer = await readFile(multiPdfPath);
+      const text = await extractText(toArrayBuffer(buffer));
+
+      expect(typeof text).toBe("string");
+      expect(text.length).toBeGreaterThan(10);
+
+      const normalized = normalizeBlock(text, L);
+
+      expect(typeof normalized).toBe("string");
+      expect(normalized.length).toBeGreaterThan(20);
+      expect(hasAlpha(normalized)).toBe(true);
+
+      expect(normalized).not.toMatch(/ {2,}/);
+      expect(normalized).not.toMatch(/\n{3,}/);
+
+      const lineCount = normNL(normalized).split("\n").length;
+      expect(lineCount).toBeGreaterThan(2);
+    },
+    30_000
+  );
+
+  it("end-to-end on synthetic text (no PDF)", async () => {
+    const raw = [
+      "Jan 2020 – Present",
+      "Desenvolvi um sis-",
+      "tema em Node.js  ",
+      "- Bullet A",
+      "- Bullet B",
+      "Mar 2019 - Jul 2021",
+    ].join("\n");
+
+    const out = normalizeBlock(raw, L);
+    const HAY = normNL(out);
+
+    const DESC_RE = /Desenvolvi\s+um\s+sistema\s+em\s+Node\.js/;
+    const BULLET_A_RE = /[–-][\s\u00A0]*Bullet A\b/;
+    const BULLET_B_RE = /[–-][\s\u00A0]*Bullet B\b/;
+
+    expect(HAY).toContain("2020-01 - Present");
+    expect(HAY).toMatch(DESC_RE);
+    expect(HAY).toMatch(BULLET_A_RE);
+    expect(HAY).toMatch(BULLET_B_RE);
+    expect(HAY).toContain("2019-03 - 2021-07");
+
+    const idxDateOpen = HAY.indexOf("2020-01 - Present");
+    const idxDesc = HAY.search(DESC_RE);
+    const idxBulletA = HAY.search(BULLET_A_RE);
+    const idxBulletB = HAY.search(BULLET_B_RE);
+    const idxDateEnd = HAY.indexOf("2019-03 - 2021-07");
+
+    expect(idxDateOpen).toBeGreaterThanOrEqual(0);
+    expect(idxDesc).toBeGreaterThan(idxDateOpen);
+    expect(idxBulletA).toBeGreaterThan(idxDesc);
+    expect(idxBulletB).toBeGreaterThan(idxBulletA);
+    expect(idxDateEnd).toBeGreaterThan(idxBulletB);
+
+    expect(HAY).not.toMatch(/ {2,}/);
+    expect(HAY).not.toMatch(/\n{3,}/);
+  });
+});


### PR DESCRIPTION
This PR implements the **resume text normalization pipeline**.

- Added `normalizeWhitespace`, `smartJoinLines`, and `normalizeDateRanges` helpers in `/lib/parser/normalize.ts`.
- Combined them into `normalizeBlock` to run the full pipeline.
- Integrated `NormalizeOptions` for flexible configuration (whitespace, join lines, extra date patterns).
- Added unit and integration tests (with PDF fixtures) to validate normalization.